### PR TITLE
Fix config issue where there is no active tool when klipper starts

### DIFF
--- a/klipper/config/tools.cfg
+++ b/klipper/config/tools.cfg
@@ -14,6 +14,9 @@ initial_duration: 1
 gcode:
     RESPOND TYPE=echo MSG='Updating active tool from probe status.'
     DETECT_ACTIVE_TOOL_PROBE
+    {% if printer.tool_probe_endstop.active_tool_number != -1 %}
+      M568 P{printer.tool_probe_endstop.active_tool_number} A2
+    {% endif %}
     SAVE_CURRENT_TOOL T={printer.tool_probe_endstop.active_tool_number}       
 
 [toolgroup 0]

--- a/klipper/config/tools_macros.cfg
+++ b/klipper/config/tools_macros.cfg
@@ -161,3 +161,51 @@ gcode:
     {% set newparameters = newparameters ~ " TOLERANCE=2" %}                             # Set Tolerance to default of 2.
   {% endif %}
   TEMPERATURE_WAIT_WITH_TOLERANCE{newparameters}
+
+[gcode_macro M568]
+description: Pnnn Rnnn Snnn An Nnnn Mnnn
+  Set tool temperature.
+  P= Tool number, optional. If this parameter is not provided, the current tool is used.
+  R= Standby temperature(s), optional
+  S= Active temperature(s), optional
+  A = Heater State, optional: 0 = off, 1 = standby temperature(s), 2 = active temperature(s).
+  N = Time in seconds to wait between changing heater state to standby and setting heater target temperature to standby temperature when standby temperature is lower than tool temperature.
+      Use for example 0.1 to change immediately to standby temperature.
+  O = Time in seconds to wait from docking tool to shutting off the heater, optional.
+      Use for example 86400 to wait 24h if you want to disable shutdown timer.
+gcode:
+#  RESPOND MSG="M568: Seting new temperature: {rawparams}"
+  {% set newparameters = "" %}  # Parameters to be passed to subroutines in new format.
+
+  # P= Tool number
+  {% if params.P is defined %}
+    {% set newparameters = newparameters ~ " TOOL="~params.P %}                   # Set heater_standby_temp to new parameters.
+  {% endif %}
+
+  # R= Standby temperature
+  {% if params.R is defined %}
+    {% set newparameters = newparameters ~ " STDB_TMP="~params.R %}                   # Set heater_standby_temp to new parameters.
+  {% endif %}
+
+  # S= Active temperature
+  {% if params.S is defined %}
+    {% set newparameters = newparameters ~ " ACTV_TMP="~params.S %}                    # Set heater_active_temp to new parameters.
+  {% endif %}
+
+  # N = Time in seconds to wait from docking tool to putting the heater in standy
+  {% if params.N is defined %}
+    {% set newparameters = newparameters ~ " STDB_TIMEOUT="~params.N %}                  # Set idle_to_standby_time to new parameters.
+  {% endif %}
+
+  # M = Time in seconds to wait from docking tool to shuting off the heater
+  {% if params.O is defined %}
+    {% set newparameters = newparameters ~ " SHTDWN_TIMEOUT="~params.O %}                  # Set idle_to_powerdown_time to new parameters.
+  {% endif %}
+
+  # A = Heater State, optional: 0 = off, 1 = standby temperature(s), 2 = active temperature
+  {% if params.A is defined %}
+    {% set newparameters = newparameters ~ " CHNG_STATE="~params.A %}                            # Set idle_to_powerdown_time to new parameters.
+  {% endif %}
+
+#  {action_respond_info("M568: Running: SET_TOOL_TEMPERATURE"~newparameters)}
+  SET_TOOL_TEMPERATURE{newparameters}


### PR DESCRIPTION
I copied the config from this repository with very minor changes and when I tried to do a first print (single extruder, but with all the tapchanger config in place) the heater would simply not heat up. I'm using PrusaSlicer 2.6.0 RC which has klipper gcode support but I don't expect the slicer to be a factor.

The issue was that `M104`/`M109` simply had no effect. When calling e.g. `M104 T0 S255` the expected behavior is for the first heater temperature to be set to 150, but that wasn't happening, the heater would stay "off". After lots of reading I realized that calling `SET_TOOL_TEMPERATURE TOOL=0 CHNG_STATE=2` before `M104` would work as expected, that leads me to think the heater is never set to active after the printer boots up.

In summary, to reproduce:
1) Configure klipper with the config from this repo
2) Reboot the printer, call `M104 T0 S255`
3) Notice the heater state doesn't change

In `pickup_gcode` there is a line that changes the state of the current extruder's heater to active:
```gcode
pickup_gcode: 
  M568 P{myself.name} A2                                               # Put tool heater in Active mode 
```

However unless the tool is dropped off and picked up before every print there's no guarantee the pickup gcode will be called. Unless the slicer you are using adds `M568` gcode too, but that isn't the case with PrusaSlicer.

To solve the issue I added a call to `M568` after the active tool is detected after boot. I also added the `M568` macro from `Klipper_ToolChanger/klipper_macros/M568.cfg` in `tools_macros.cfg` since it was not available for me, I'm not sure why it is available for you locally but it's not part of the config in github (perhaps some late config changes?).