### PR TITLE
Don't clear out Z g-code offset before tool dropoff

### DIFF
--- a/klipper/config/tools.cfg
+++ b/klipper/config/tools.cfg
@@ -26,7 +26,7 @@ dropoff_gcode:
     BED_MESH_PROFILE SAVE=toolchange  
     BED_MESH_CLEAR
   {% endif %}
-  SET_GCODE_OFFSET X=0 Y=0 Z=0                                 # Set XY offset to 0 so we park the tool right.
+  SET_GCODE_OFFSET X=0 Y=0                                     # Set XY offset to 0 so we park the tool right.
   {% if myself.zone[0] == "0" %} 
     T_DROPOFF_APPROACH X={myself.park[0]} Y={myself.park[1]} Z={myself.park[2]} YS={myself.zone[1]}
   {% elif myself.zone[0] == "1" %} 


### PR DESCRIPTION
I think this PR will fix a bug that happens when I home with any tool other than `tool 0` and then try to dropoff the tool.

The homing routine cancels out the g-code offset here:

https://github.com/viesturz/tapchanger/blob/bc812ec4260aa7eb2404df0c66ff36a986b6d0c9/klipper/config/homing.cfg#L41-L46

What this G-code does is move the toolhead to 30mm and then sets the kinematic position to be "30mm + offset", then sets the offset by calling `KTCC_SET_GCODE_OFFSET_FOR_CURRENT_TOOL`, which effectively cancels out the offset. For example if the tool has a `-1` offset in Z, we would move +30mm off the bed, then tell the printer this position is actually `Z=29`. When we apply the `-1` G-code offset and later issue `G0 Z30` we will actually move our previously defined `Z=29` position which is actually 30mm off the bed. This is all very logical since the homing routine is what sets the zero, there's no need to add or substract an additional offset.

But the dropoff code later sets the Z offset to 0 here:

https://github.com/viesturz/tapchanger/blob/bc812ec4260aa7eb2404df0c66ff36a986b6d0c9/klipper/config/tools.cfg#L29

Which means the Z offset is no longer applied, the toolhead will be in the wrong location.

Steps to reproduce:
1) Set a large G-code offset for one of the toolhead just to demonstrate the issue
2) Home the printer with the toolhead which has an offset
3) Try to dropoff the tool, the offset is removed and the dropoff may fail

I can see in your config files that your offsets are tiny (~0.16mm) which could be why this hasn't been a problem so far.